### PR TITLE
pass empty dict if data is None in trigger()

### DIFF
--- a/examples/events/__main__.py
+++ b/examples/events/__main__.py
@@ -26,7 +26,7 @@ class Observer:
         """An input's mute state has changed."""
         print(f"{data.input_name} mute toggled")
 
-    def on_exit_started(self, data):
+    def on_exit_started(self, _):
         """OBS has begun the shutdown process."""
         print(f"OBS closing!")
         self._cl.unsubscribe()

--- a/obsws_python/baseclient.py
+++ b/obsws_python/baseclient.py
@@ -35,10 +35,9 @@ class ObsClient:
 
     def _conn_from_toml(self):
         filepath = Path.cwd() / "config.toml"
-        self._conn = dict()
         with open(filepath, "rb") as f:
-            self._conn = tomllib.load(f)
-        return self._conn["connection"]
+            conn = tomllib.load(f)
+        return conn["connection"]
 
     def authenticate(self):
         secret = base64.b64encode(

--- a/obsws_python/events.py
+++ b/obsws_python/events.py
@@ -61,7 +61,7 @@ class EventClient:
                 self.data["d"].get("eventType"),
                 self.data["d"].get("eventData"),
             )
-            self.callback.trigger(event, data)
+            self.callback.trigger(event, data if data else {})
             time.sleep(self.DELAY)
 
     def unsubscribe(self):
@@ -69,3 +69,4 @@ class EventClient:
         stop listening for events
         """
         self.running = False
+        self.base_client.ws.close()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 HERE = pathlib.Path(__file__).parent
 
 
-VERSION = "1.1.0"
+VERSION = "1.1.1"
 PACKAGE_NAME = "obsws-python"
 AUTHOR = "Adem Atikturk"
 AUTHOR_EMAIL = "aatikturk@gmail.com"


### PR DESCRIPTION
Hi Adem.

This PR introduces the following changes:

- pass empty dict if data is None in trigger(). Fixes bug where event defines no Data Fields.
- remove redundant assignment in conn_from_toml
- add explicit call to ws.close() in unsubscribe()
- patch bump

Thanks for your time mate.