### PR TITLE
allow use without installing tomllib

### DIFF
--- a/obsws_python/baseclient.py
+++ b/obsws_python/baseclient.py
@@ -6,9 +6,13 @@ from pathlib import Path
 from random import randint
 
 try:
-    import tomllib
+    try:
+        import tomllib
+    except ModuleNotFoundError:
+        import tomli as tomllib
 except ModuleNotFoundError:
-    import tomli as tomllib
+    # ObsClient(host='...', port='...', password='...') must be used
+    tomllib = None
 
 import websocket
 
@@ -21,7 +25,12 @@ class ObsClient:
     def __init__(self, **kwargs):
         defaultkwargs = {"host": "localhost", "port": 4455, "password": None, "subs": 0}
         if not any(key in kwargs for key in ("host", "port", "password")):
-            kwargs |= self._conn_from_toml()
+            if tomllib:
+                kwargs |= self._conn_from_toml()
+            else:
+                raise ModuleNotFoundError(
+                        "tomllib not installed; Perhaps use "
+                        "ObsClient(host='...', port='...', password='...')")
         kwargs = defaultkwargs | kwargs
         for attr, val in kwargs.items():
             setattr(self, attr, val)

--- a/obsws_python/baseclient.py
+++ b/obsws_python/baseclient.py
@@ -5,15 +5,6 @@ import logging
 from pathlib import Path
 from random import randint
 
-try:
-    try:
-        import tomllib
-    except ModuleNotFoundError:
-        import tomli as tomllib
-except ModuleNotFoundError:
-    # ObsClient(host='...', port='...', password='...') must be used
-    tomllib = None
-
 import websocket
 
 from .error import OBSSDKError
@@ -25,12 +16,7 @@ class ObsClient:
     def __init__(self, **kwargs):
         defaultkwargs = {"host": "localhost", "port": 4455, "password": None, "subs": 0}
         if not any(key in kwargs for key in ("host", "port", "password")):
-            if tomllib:
-                kwargs |= self._conn_from_toml()
-            else:
-                raise ModuleNotFoundError(
-                        "tomllib not installed; Perhaps use "
-                        "ObsClient(host='...', port='...', password='...')")
+            kwargs |= self._conn_from_toml()
         kwargs = defaultkwargs | kwargs
         for attr, val in kwargs.items():
             setattr(self, attr, val)
@@ -46,6 +32,10 @@ class ObsClient:
         self.server_hello = json.loads(self.ws.recv())
 
     def _conn_from_toml(self) -> dict:
+        try:
+            import tomllib
+        except ModuleNotFoundError:
+            import tomli as tomllib
         conn = {}
         filepath = Path.cwd() / "config.toml"
         if filepath.exists():


### PR DESCRIPTION
When ObsClient(host='...', port='...', password='...') are provided, importing tomllib is not actually necessary.  Allow for tomllib to not be installed at all, and only raise a tomllib ModuleNotFoundError if (host, port, password) are not provided.