### PR TITLE
check user home directory for config.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ port = 4455
 password = "mystrongpass"
 ```
 
-It should be placed next to your `__main__.py` file.
+It should be placed in your user home directory.
 
 #### Otherwise:
 

--- a/examples/events/README.md
+++ b/examples/events/README.md
@@ -6,7 +6,7 @@ Registers a list of callback functions to hook into OBS events.
 
 Simply run the code and trigger the events, press `<Enter>` to exit.
 
-This example assumes the existence of a `config.toml`, placed next to `__main__.py`:
+This example assumes the existence of a `config.toml`, placed in your user home directory:
 
 ```toml
 [connection]

--- a/examples/hotkeys/README.md
+++ b/examples/hotkeys/README.md
@@ -8,7 +8,7 @@ Requires [Python Keyboard library](https://github.com/boppreh/keyboard).
 
 Simply run the code and press the assigned hotkeys. Press `ctrl+enter` to exit.
 
-This example assumes the existence of a `config.toml`, placed next to `__main__.py`:
+This example assumes the existence of a `config.toml`, placed in your user home directory:
 
 ```toml
 [connection]

--- a/examples/levels/README.md
+++ b/examples/levels/README.md
@@ -4,7 +4,7 @@ Prints POSTFADER level values for audio device `Desktop Audio`. If mute toggled 
 
 ## Use
 
-This example assumes the existence of a `config.toml`, placed next to `__main__.py`:
+This example assumes the existence of a `config.toml`, placed in your user home directory:
 
 ```toml
 [connection]

--- a/examples/scene_rotate/README.md
+++ b/examples/scene_rotate/README.md
@@ -4,7 +4,7 @@ Collects the names of all available scenes, rotates through them and prints thei
 
 ## Use
 
-This example assumes the existence of a `config.toml`, placed next to `__main__.py`:
+This example assumes the existence of a `config.toml`, placed in your user home directory:
 
 ```toml
 [connection]

--- a/obsws_python/baseclient.py
+++ b/obsws_python/baseclient.py
@@ -4,6 +4,7 @@ import json
 import logging
 from pathlib import Path
 from random import randint
+from typing import Optional
 
 import websocket
 
@@ -36,11 +37,26 @@ class ObsClient:
             import tomllib
         except ModuleNotFoundError:
             import tomli as tomllib
+
+        def get_filepath() -> Optional[Path]:
+            """
+            traverses a list of paths for a 'config.toml'
+            returns the first config file found or None.
+            """
+            filepaths = [
+                Path.cwd() / "config.toml",
+                Path.home() / "config.toml",
+                Path.home() / ".config" / "obsws-python" / "config.toml",
+            ]
+            for filepath in filepaths:
+                if filepath.exists():
+                    return filepath
+
         conn = {}
-        filepath = Path.cwd() / "config.toml"
-        if filepath.exists():
+        if filepath := get_filepath():
             with open(filepath, "rb") as f:
                 conn = tomllib.load(f)
+            self.logger.info(f"loading config from {filepath}")
         return conn["connection"] if "connection" in conn else conn
 
     def authenticate(self):

--- a/obsws_python/version.py
+++ b/obsws_python/version.py
@@ -1,1 +1,1 @@
-version = "1.4.1"
+version = "1.4.2"


### PR DESCRIPTION
Hello Adem, this PR introduces the following:

- _conn_from_toml() in baseclient now checks the user home directory as well as cwd for existence of config.toml. If multiple config.toml exist only the first one found is returned in the following order:
```python
                Path.cwd() / "config.toml",
                Path.home() / "config.toml",
                Path.home() / ".config" / "obsws-python" / "config.toml",
```
- project README as well as example readmes updated to advise placing config.toml in user home directory.

Reason for change, cwd might change depending on how the consumer code is launched. fixes #23.

- [x] all tests pass
- [x] patch bump

Thanks for your time mate!

