### PR TITLE
Added 'timeout' option for  baseclient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ venv.bak/
 # Test/config
 quick.py
 config.toml
+obsws.log
+
+.vscode/

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ By default the clients connect with parameters:
 -   `host`: "localhost"
 -   `port`: 4455
 -   `password`: ""
-
+-   `timeout`: 3
 You may override these parameters by storing them in a toml config file or passing them as keyword arguments.
 
 Order of precedence: keyword arguments then config file then default values.
@@ -41,6 +41,7 @@ A valid `config.toml` might look like this:
 host = "localhost"
 port = 4455
 password = "mystrongpass"
+timeout = 3
 ```
 
 It should be placed in your user home directory.
@@ -53,7 +54,7 @@ Example `__main__.py`:
 import obsws_python as obs
 
 # pass conn info if not in config.toml
-cl = obs.ReqClient(host='localhost', port=4455, password='mystrongpass')
+cl = obs.ReqClient(host='localhost', port=4455, password='mystrongpass', timeout=3)
 
 # Toggle the mute state of your Mic input
 cl.toggle_input_mute('Mic/Aux')

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ By default the clients connect with parameters:
 -   `host`: "localhost"
 -   `port`: 4455
 -   `password`: ""
--   `timeout`: 3
+
 You may override these parameters by storing them in a toml config file or passing them as keyword arguments.
 
 Order of precedence: keyword arguments then config file then default values.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ By default the clients connect with parameters:
 -   `host`: "localhost"
 -   `port`: 4455
 -   `password`: ""
+-   `timeout`: None
 
 You may override these parameters by storing them in a toml config file or passing them as keyword arguments.
 
@@ -41,7 +42,6 @@ A valid `config.toml` might look like this:
 host = "localhost"
 port = 4455
 password = "mystrongpass"
-timeout = 3
 ```
 
 It should be placed in your user home directory.
@@ -131,6 +131,8 @@ def on_scene_created(data):
 If a request fails an `OBSSDKError` will be raised with a status code.
 
 For a full list of status codes refer to [Codes](https://github.com/obsproject/obs-websocket/blob/master/docs/generated/protocol.md#requeststatus)
+
+If a timeout occurs during sending/receiving a request or receiving an event an `OBSSDKTimeoutError` will be raised.
 
 ### Logging
 

--- a/obsws_python/baseclient.py
+++ b/obsws_python/baseclient.py
@@ -7,7 +7,7 @@ from random import randint
 from typing import Optional
 
 import websocket
-
+from websocket._exceptions import WebSocketTimeoutException
 from .error import OBSSDKError
 
 
@@ -15,7 +15,7 @@ class ObsClient:
     logger = logging.getLogger("baseclient.obsclient")
 
     def __init__(self, **kwargs):
-        defaultkwargs = {"host": "localhost", "port": 4455, "password": "", "subs": 0, "timeout":3}
+        defaultkwargs = {"host": "localhost", "port": 4455, "password": "", "subs": 0, "timeout":None}
         if not any(key in kwargs for key in ("host", "port", "password")):
             kwargs |= self._conn_from_toml()
         kwargs = defaultkwargs | kwargs
@@ -107,8 +107,8 @@ class ObsClient:
         self.logger.debug(f"Sending request {payload}")
         try:
             self.ws.send(json.dumps(payload))
-        except TimeoutError:
+            response = json.loads(self.ws.recv())
+        except WebSocketTimeoutException :
             raise OBSSDKError("Timeout while trying to send the request")
-        response = json.loads(self.ws.recv())
         self.logger.debug(f"Response received {response}")
         return response["d"]

--- a/obsws_python/error.py
+++ b/obsws_python/error.py
@@ -1,4 +1,6 @@
 class OBSSDKError(Exception):
-    """general errors"""
+    """Exception raised when general errors occur"""
 
-    pass
+
+class OBSSDKTimeoutError(Exception):
+    """Exception raised when a connection times out"""

--- a/obsws_python/reqs.py
+++ b/obsws_python/reqs.py
@@ -28,7 +28,7 @@ class ReqClient:
     def __repr__(self):
         return type(
             self
-        ).__name__ + "(host='{host}', port={port}, password='{password}')".format(
+        ).__name__ + "(host='{host}', port={port}, password='{password}', timeout={timeout})".format(
             **self.base_client.__dict__,
         )
 

--- a/obsws_python/version.py
+++ b/obsws_python/version.py
@@ -1,1 +1,1 @@
-version = "1.4.2"
+version = "1.4.3"

--- a/obsws_python/version.py
+++ b/obsws_python/version.py
@@ -1,1 +1,1 @@
-version = "1.4.3"
+version = "1.5.0"


### PR DESCRIPTION
Hi Onyx,
This PR is introducing following changes to fix #25 :

- Added timeout parameter for the baseclient.
```python3
 def __init__(self, **kwargs):
        defaultkwargs = {"host": "localhost", "port": 4455, "password": "", "subs": 0, "timeout":3}
```
```python3
        self.ws = websocket.WebSocket()
        self.ws.connect(f"ws://{self.host}:{self.port}", timeout=self.timeout)
        self.server_hello = json.loads(self.ws.recv())
``` 
- in the ```req```  method while sending the request exception handling implemented.
```python3
        try:
            self.ws.send(json.dumps(payload))
        except TimeoutError:
            raise OBSSDKError("Timeout while trying to send the request")
```

- [x]  tests passed
- [x] readme updated
- [x] version bumped

Thanks for your time!