### PR TITLE
auth logger for clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,11 @@ env.bak/
 venv.bak/
 .hatch
 
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+.python-version
+
 # Test/config
 quick.py
 config.toml

--- a/obsws_python/baseclient.py
+++ b/obsws_python/baseclient.py
@@ -108,9 +108,15 @@ class ObsClient:
         self.ws.send(json.dumps(payload))
         try:
             response = json.loads(self.ws.recv())
-            return response
+            if response["op"] != 2:
+                raise OBSSDKError(
+                    "failed to identify client with the server, expected response with OpCode 2 Identified"
+                )
+            return response["d"]
         except json.decoder.JSONDecodeError:
-            raise OBSSDKError("failed to identify client with the server")
+            raise OBSSDKError(
+                "failed to identify client with the server, please check connection settings"
+            )
 
     def req(self, req_type, req_data=None):
         payload = {

--- a/obsws_python/baseclient.py
+++ b/obsws_python/baseclient.py
@@ -108,7 +108,7 @@ class ObsClient:
         self.ws.send(json.dumps(payload))
         try:
             response = json.loads(self.ws.recv())
-            return response["op"] == 2
+            return response
         except json.decoder.JSONDecodeError:
             raise OBSSDKError("failed to identify client with the server")
 

--- a/obsws_python/events.py
+++ b/obsws_python/events.py
@@ -27,8 +27,9 @@ class EventClient:
         defaultkwargs = {"subs": Subs.LOW_VOLUME}
         kwargs = defaultkwargs | kwargs
         self.base_client = ObsClient(**kwargs)
-        if self.base_client.authenticate():
-            self.logger.info(f"Successfully identified {self} with the server")
+        auth_status = self.base_client.authenticate()
+        if auth_status:
+            self.logger.info(f"Successfully identified {self} with the server using rpcVersion:{auth_status['d']['negotiatedRpcVersion']}")
         self.callback = Callback()
         self.subscribe()
 

--- a/obsws_python/reqs.py
+++ b/obsws_python/reqs.py
@@ -17,9 +17,14 @@ class ReqClient:
     def __init__(self, **kwargs):
         self.logger = logger.getChild(self.__class__.__name__)
         self.base_client = ObsClient(**kwargs)
-        auth_status = self.base_client.authenticate()
-        if auth_status:
-            self.logger.info(f"Successfully identified {self} with the server using rpcVersion:{auth_status['d']['negotiatedRpcVersion']}")
+        try:
+            success = self.base_client.authenticate()
+            self.logger.info(
+                f"Successfully identified {self} with the server using RPC version:{success['negotiatedRpcVersion']}"
+            )
+        except OBSSDKError as e:
+            self.logger.error(f"{type(e).__name__}: {e}")
+            raise
 
     def __enter__(self):
         return self

--- a/obsws_python/reqs.py
+++ b/obsws_python/reqs.py
@@ -17,8 +17,9 @@ class ReqClient:
     def __init__(self, **kwargs):
         self.logger = logger.getChild(self.__class__.__name__)
         self.base_client = ObsClient(**kwargs)
-        if self.base_client.authenticate():
-            self.logger.info(f"Successfully identified {self} with the server")
+        auth_status = self.base_client.authenticate()
+        if auth_status:
+            self.logger.info(f"Successfully identified {self} with the server using rpcVersion:{auth_status['d']['negotiatedRpcVersion']}")
 
     def __enter__(self):
         return self

--- a/obsws_python/version.py
+++ b/obsws_python/version.py
@@ -1,1 +1,1 @@
-version = "1.5.1"
+version = "1.5.2"


### PR DESCRIPTION
hi mate.
This PR makes following changes in base, reqs and events clients:
- added RpcVersion in auth loggers for both requests and events clients. 
- removed the check `return response["op"] == 2` in baseclient auth function and returned the whole response.