### PR TITLE
Add disconnect() methods. Default ws timeout to None for event thread.

### DIFF
--- a/examples/events/__main__.py
+++ b/examples/events/__main__.py
@@ -17,6 +17,12 @@ class Observer:
         print(f"Registered events: {self._client.callback.get()}")
         self.running = True
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self._client.disconnect()
+
     def on_current_program_scene_changed(self, data):
         """The current program scene has changed."""
         print(f"Switched to scene {data.scene_name}")
@@ -31,13 +37,11 @@ class Observer:
 
     def on_exit_started(self, _):
         """OBS has begun the shutdown process."""
-        print(f"OBS closing!")
-        self._client.unsubscribe()
+        print("OBS closing!")
         self.running = False
 
 
 if __name__ == "__main__":
-    observer = Observer()
-
-    while observer.running:
-        time.sleep(0.1)
+    with Observer() as observer:
+        while observer.running:
+            time.sleep(0.1)

--- a/examples/hotkeys/__main__.py
+++ b/examples/hotkeys/__main__.py
@@ -1,6 +1,7 @@
 import inspect
 
 import keyboard
+
 import obsws_python as obs
 
 
@@ -9,6 +10,12 @@ class Observer:
         self._client = obs.EventClient()
         self._client.callback.register(self.on_current_program_scene_changed)
         print(f"Registered events: {self._client.callback.get()}")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self._client.disconnect()
 
     @property
     def event_identifier(self):
@@ -31,13 +38,12 @@ def set_scene(scene, *args):
 
 
 if __name__ == "__main__":
-    req_client = obs.ReqClient()
-    observer = Observer()
+    with obs.ReqClient() as req_client:
+        with Observer() as observer:
+            keyboard.add_hotkey("0", version)
+            keyboard.add_hotkey("1", set_scene, args=("START",))
+            keyboard.add_hotkey("2", set_scene, args=("BRB",))
+            keyboard.add_hotkey("3", set_scene, args=("END",))
 
-    keyboard.add_hotkey("0", version)
-    keyboard.add_hotkey("1", set_scene, args=("START",))
-    keyboard.add_hotkey("2", set_scene, args=("BRB",))
-    keyboard.add_hotkey("3", set_scene, args=("END",))
-
-    print("press ctrl+enter to quit")
-    keyboard.wait("ctrl+enter")
+            print("press ctrl+enter to quit")
+            keyboard.wait("ctrl+enter")

--- a/examples/levels/__main__.py
+++ b/examples/levels/__main__.py
@@ -9,6 +9,8 @@ LEVELTYPE = IntEnum(
     start=0,
 )
 
+DEVICE = "Desktop Audio"
+
 
 def on_input_mute_state_changed(data):
     """An input's mute state has changed."""
@@ -32,15 +34,14 @@ def on_input_volume_meters(data):
 
 
 def main():
-    client = obs.EventClient(subs=(obs.Subs.LOW_VOLUME | obs.Subs.INPUTVOLUMEMETERS))
-    client.callback.register([on_input_volume_meters, on_input_mute_state_changed])
+    with obs.EventClient(
+        subs=(obs.Subs.LOW_VOLUME | obs.Subs.INPUTVOLUMEMETERS)
+    ) as client:
+        client.callback.register([on_input_volume_meters, on_input_mute_state_changed])
 
-    while cmd := input("<Enter> to exit>\n"):
-        if not cmd:
-            break
+        while _ := input("<Enter> to exit>\n"):
+            pass
 
 
 if __name__ == "__main__":
-    DEVICE = "Desktop Audio"
-
     main()

--- a/examples/levels/__main__.py
+++ b/examples/levels/__main__.py
@@ -39,7 +39,7 @@ def main():
     ) as client:
         client.callback.register([on_input_volume_meters, on_input_mute_state_changed])
 
-        while _ := input("<Enter> to exit>\n"):
+        while _ := input("Press <Enter> to exit\n"):
             pass
 
 

--- a/obsws_python/events.py
+++ b/obsws_python/events.py
@@ -52,6 +52,7 @@ class EventClient:
         return type(self).__name__
 
     def subscribe(self):
+        self.base_client.ws.settimeout(None)
         stop_event = threading.Event()
         self.worker = threading.Thread(
             target=self.trigger, daemon=True, args=(stop_event,)

--- a/obsws_python/events.py
+++ b/obsws_python/events.py
@@ -67,8 +67,8 @@ class EventClient:
         """
         while not stop_event.is_set():
             try:
-                if r := self.base_client.ws.recv():
-                    event = json.loads(r)
+                if response := self.base_client.ws.recv():
+                    event = json.loads(response)
                     self.logger.debug(f"Event received {event}")
                     type_, data = (
                         event["d"].get("eventType"),

--- a/obsws_python/events.py
+++ b/obsws_python/events.py
@@ -78,7 +78,7 @@ class EventClient:
             except WebSocketTimeoutException as e:
                 self.logger.exception(f"{type(e).__name__}: {e}")
                 raise OBSSDKTimeoutError("Timeout while waiting for event") from e
-            except WebSocketConnectionClosedException as e:
+            except (WebSocketConnectionClosedException, OSError) as e:
                 self.logger.debug(f"{type(e).__name__} terminating the event thread")
                 stop_event.set()
 

--- a/obsws_python/reqs.py
+++ b/obsws_python/reqs.py
@@ -31,7 +31,7 @@ class ReqClient:
         return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
-        self.base_client.ws.close()
+        self.disconnect()
 
     def __repr__(self):
         return type(
@@ -42,6 +42,9 @@ class ReqClient:
 
     def __str__(self):
         return type(self).__name__
+    
+    def disconnect(self):
+        self.base_client.ws.close()
 
     def send(self, param, data=None, raw=False):
         try:

--- a/obsws_python/version.py
+++ b/obsws_python/version.py
@@ -1,1 +1,1 @@
-version = "1.7.0b0"
+version = "1.7.0"

--- a/obsws_python/version.py
+++ b/obsws_python/version.py
@@ -1,1 +1,1 @@
-version = "1.6.2"
+version = "1.7.0b0"


### PR DESCRIPTION
Hi Adem.

This PR introduces the following changes:

ReqClient:
- disconnect() method added

EventClient:
- disconnect() method added, aliased as unsubscribe.
- __enter__(), __exit__() methods added to support context manager
- trigger() checks for non-empty response before passing it to json.loads()
- trigger() now uses event object, listens until event object is set and sets it on WebSocketConnectionClosedException or OSError.
- by default, websocket timeout is removed in subscribe(). This has the following implication for the Event client only, the timeout kwarg will apply only to the initial connection.

I've updated the examples to demonstrate use of the disconnect() methods.

Version has been bumped to 1.7.0b0, we might give this one a bit of time for testing in case we decide to reverse something.

- [x] All tests pass

This PR addresses #41 and #42.