### PR TITLE
Return response class for toggle_record

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,9 @@ logging.basicConfig(level=logging.DEBUG)
 
 Install [hatch][hatch-install] and then:
 
-`hatch test`
+```
+hatch test
+```
 
 ### Official Documentation
 

--- a/obsws_python/reqs.py
+++ b/obsws_python/reqs.py
@@ -1784,7 +1784,7 @@ class ReqClient:
 
 
         """
-        self.send("ToggleRecord")
+        return self.send("ToggleRecord")
 
     def start_record(self):
         """

--- a/obsws_python/version.py
+++ b/obsws_python/version.py
@@ -1,1 +1,1 @@
-version = "1.7.1"
+version = "1.7.2"

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -13,35 +13,8 @@ class TestRequests:
 
     def test_get_hot_key_list(self):
         resp = req_cl.get_hot_key_list()
-        obsbasic_hotkey_list = [
-            "OBSBasic.SelectScene",
-            "OBSBasic.QuickTransition.1",
-            "OBSBasic.QuickTransition.2",
-            "OBSBasic.QuickTransition.3",
-            "OBSBasic.StartStreaming",
-            "OBSBasic.StopStreaming",
-            "OBSBasic.ForceStopStreaming",
-            "OBSBasic.StartRecording",
-            "OBSBasic.StopRecording",
-            "OBSBasic.PauseRecording",
-            "OBSBasic.UnpauseRecording",
-            "OBSBasic.SplitFile",
-            "OBSBasic.StartReplayBuffer",
-            "OBSBasic.StopReplayBuffer",
-            "OBSBasic.StartVirtualCam",
-            "OBSBasic.StopVirtualCam",
-            "OBSBasic.EnablePreview",
-            "OBSBasic.DisablePreview",
-            "OBSBasic.EnablePreviewProgram",
-            "OBSBasic.DisablePreviewProgram",
-            "OBSBasic.ShowContextBar",
-            "OBSBasic.HideContextBar",
-            "OBSBasic.Transition",
-            "OBSBasic.ResetStats",
-            "OBSBasic.Screenshot",
-            "OBSBasic.SelectedSourceScreenshot",
-        ]
-        assert all(x in resp.hotkeys for x in obsbasic_hotkey_list)
+        assert resp.hotkeys
+        assert any(x.startswith("OBSBasic.") for x in resp.hotkeys)
 
     @pytest.mark.parametrize(
         "name,data",


### PR DESCRIPTION
Hi Adem, this PR makes two changes:

- Ensure {ReqClient}.toggle_record() returns a response class in order to access the [outputActive](https://github.com/obsproject/obs-websocket/blob/master/docs/generated/protocol.md#togglerecord) field.
- update hotkey list test to make it more flexible. Now it checks for a non-empty response with at least one OBSBasic hotkey.
- patch bump

Thanks.