### PR TITLE
add v5.4, v5.5 methods

### DIFF
--- a/obsws_python/reqs.py
+++ b/obsws_python/reqs.py
@@ -1100,6 +1100,14 @@ class ReqClient:
         payload = {"position": pos, "release": release}
         self.send("SetTBarPosition", payload)
 
+    def get_source_filter_kind_list(self):
+        """
+        Gets an array of all available source filter kinds.
+
+
+        """
+        return self.send("GetSourceFilterKindList")
+
     def get_source_filter_list(self, name):
         """
         Gets a list of all of a source's filters.
@@ -1310,6 +1318,23 @@ class ReqClient:
             "searchOffset": offset,
         }
         return self.send("GetSceneItemId", payload)
+
+    def get_scene_item_source(self, scene_name, scene_item_id):
+        """
+        Gets the source associated with a scene item.
+
+        :param scene_item_id: Numeric ID of the scene item (>= 0)
+        :type scene_item_id: int
+        :param scene_name: Name of the scene the item is in.
+        :type scene_name: str
+
+
+        """
+        payload = {
+            "sceneItemId": scene_item_id,
+            "sceneName": scene_name,
+        }
+        return self.send("GetSceneItemSource", payload)
 
     def create_scene_item(self, scene_name, source_name, enabled=None):
         """
@@ -1825,6 +1850,28 @@ class ReqClient:
 
         """
         self.send("ResumeRecord")
+
+    def split_record_file(self):
+        """
+        Splits the current file being recorded into a new file.
+
+
+        """
+        self.send("SplitRecordFile")
+
+    def create_record_chapter(self, chapter_name=None):
+        """
+        Adds a new chapter marker to the file currently being recorded.
+
+        Note: As of OBS 30.2.0, the only file format supporting this feature is Hybrid MP4.
+
+        :param chapter_name: Name of the new chapter
+        :type chapter_name: str
+
+
+        """
+        payload = {"chapterName": chapter_name}
+        self.send("CreateRecordChapter", payload)
 
     def get_media_input_status(self, name):
         """

--- a/obsws_python/version.py
+++ b/obsws_python/version.py
@@ -1,1 +1,1 @@
-version = "1.7.2"
+version = "1.8.0"


### PR DESCRIPTION
Hi Adem, this PR adds the following v5.4, v5.5 methods:

v5.4:
- get_source_filter_kind_list
- get_scene_item_source

v5.5:
- split_record_file
- create_record_chapter

Regarding [GetSceneItemSource](https://github.com/obsproject/obs-websocket/blob/master/docs/generated/protocol.md#getsceneitemsource), it accepts an optional sceneUuid field (I assume instead of a sceneName), as many of the other requests do. However, we haven't implemented that for any of the other methods so for consistency I haven't added it to get_scene_item_source. If we wanted to add uuid parameter support then we'd want to make scene_name and scene_uuid optional parameters which would introduce a breaking change. I'm not sure if we want to (or need to) go down that road?

Thanks.